### PR TITLE
Add remaining request logic

### DIFF
--- a/Instagram/Core/Proxy.php
+++ b/Instagram/Core/Proxy.php
@@ -51,6 +51,12 @@ class Proxy {
     protected $api_url = 'https://api.instagram.com/v1';
 
     /**
+     * @var int
+     * @access protected
+     */
+    protected $requests_remaining = -1;
+
+    /**
      * Constructor
      *
      * @param \Instagram\Net\ClientInterface $client HTTP Client
@@ -301,6 +307,15 @@ class Proxy {
             sprintf( '%s/locations/%s', $this->api_url, $id )
         );
         return $response->getData();
+    }
+
+    /**
+     * Get the number of requests remaining for this client.  Returns -1 if unknown
+     *
+     * @return int
+     */
+    public function getRequestsRemaining() {
+        return $this->requests_remaining;
     }
 
     /**
@@ -557,6 +572,12 @@ class Proxy {
                 return false;
             }
         }
+
+        $headers = $response->getHeaders();
+        if (isset($headers['X-Ratelimit-Remaining'])) {
+            $this->requests_remaining = $headers['X-Ratelimit-Remaining'];
+        }
+
         return $response;
     }
 

--- a/Instagram/Instagram.php
+++ b/Instagram/Instagram.php
@@ -280,4 +280,12 @@ class Instagram extends \Instagram\Core\BaseObjectAbstract {
         return new TagMediaCollection( $this->proxy->getTagMedia( $tag, $params ), $this->proxy );
     }
 
+    /**
+     * Return the number of requests remaining on this client connection
+     * @return int
+     */
+    public function getRequestsRemaining() {
+        return $this->proxy->getRequestsRemaining();
+    }
+
 }

--- a/Instagram/Net/CurlClient.php
+++ b/Instagram/Net/CurlClient.php
@@ -97,6 +97,7 @@ class CurlClient implements ClientInterface {
         $this->curl = curl_init();
         curl_setopt( $this->curl, CURLOPT_RETURNTRANSFER, true );
         curl_setopt( $this->curl, CURLOPT_SSL_VERIFYPEER, false );
+        curl_setopt($this->curl, CURLOPT_HEADER, 1);
     }
 
     /**


### PR DESCRIPTION
In short the ApiResponse copies the latest remainder count into the current client.

``` PHP
    $instagram = new Instagram\Instagram;
    $instagram->setClientID(INSIGHTS_INSTAGRAM_CLIENT_ID);

    / /  Make lots of requests....

    $count = $instagram->getRequestsRemaining();

    if ($count < 10) {
             //  Do something about it
    }
```
